### PR TITLE
fix: reset page size during filtering and sorting

### DIFF
--- a/src/features/ProductsCatalog/index.jsx
+++ b/src/features/ProductsCatalog/index.jsx
@@ -33,6 +33,9 @@ const ProductsCatalog = () => {
       setPreferences((prev) => ({
         ...prev,
         [key]: value,
+        ...(key === 'filters' || key === 'sortOption'
+          ? { limit: PAGE_SIZE }
+          : {}),
       }));
     },
     [setPreferences]


### PR DESCRIPTION
## Proposed Changes

Description
added reset functionality for page limit during filtering and sorting

## Validation

What tests did you perform prior to submitting the PR?

- [ ] Haven't tested
- [X] On my local machine with no traceability
- [ ] Unit tests
- [ ] On a remote environment
- [ ] Irrelevant (documentation, indentation,...)

If you haven't tested your changes, please specify why and how can we make sure your PR works as expected.

## Type of Change

What type of change does your code introduce?

- [ ] Added (New Feature, documentation)
- [ ] Changed (changes in existing functionality)
- [ ] Deprecated (For soon to be removed code)
- [ ] Removed
- [X] Fixed
- [ ] Refactor
